### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/SerialModem/keywords.txt
+++ b/SerialModem/keywords.txt
@@ -5,9 +5,9 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-SerialModem        KEYWORD1
-SerialModemClient  KEYWORD1
-SerialModemGPS     KEYWORD1
+SerialModem	KEYWORD1
+SerialModemClient	KEYWORD1
+SerialModemGPS	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -17,5 +17,5 @@ SerialModemGPS     KEYWORD1
 #######################################
 # Constants (LITERAL1)
 #######################################
-Modem_MTSMC_H5 0 LITERAL1
-Modem_SIM5218  1 LITERAL1
+Modem_MTSMC_H5	LITERAL1
+Modem_SIM5218	LITERAL1


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords